### PR TITLE
表单生成-添加字段校验文件生成(针对毕晟平台)

### DIFF
--- a/interfaces/common.ts
+++ b/interfaces/common.ts
@@ -3,10 +3,10 @@
  * @公司: thundersdata
  * @作者: 陈杰
  * @Date: 2020-04-29 21:58:39
- * @LastEditors: 黄姗姗
- * @LastEditTime: 2020-05-28 18:53:47
+ * @LastEditors: 廖军
+ * @LastEditTime: 2020-10-09 17:03:40
  */
-import { Store } from "antd/lib/form/interface";
+import { Store } from 'antd/lib/form/interface';
 import { ColumnType } from 'antd/lib/table';
 
 export type FormItemType =
@@ -78,3 +78,19 @@ export type ConfigProps = {
   tableConfig?: Store;
   columns?: ColumnType<any>[];
 };
+
+/**
+ * 表字段验证配置
+ */
+export interface TableVerificationRuleList {
+  appVerificationRuleCode: string;
+  tableCode: string;
+  tableName: string;
+  tableFieldCode: string;
+  isRequired: boolean;
+  requiredMaxLength: number;
+  requiredMinLength: number;
+  fieldName: string;
+  fieldType: string;
+  pattern: string;
+}

--- a/src/manage/templates/longDetail.ts
+++ b/src/manage/templates/longDetail.ts
@@ -3,8 +3,8 @@
  * @公司: thundersdata
  * @作者: 陈杰
  * @Date: 2020-05-08 16:05:30
- * @LastEditors: 黄姗姗
- * @LastEditTime: 2020-05-25 09:47:49
+ * @LastEditors: 廖军
+ * @LastEditTime: 2020-10-09 15:38:34
  */
 import { transformFormItemLines, generateBreadcrumbs } from './util';
 import { CardItemProps } from '../../../interfaces/common';
@@ -54,9 +54,9 @@ export default function generateLongFormCode(payload: Payload): string {
         console.log('emptyline');
         const { loading } = useRequest(API.${initialFetch && initialFetch.length === 3 ? `${initialFetch[0]}.${initialFetch[1]}.${
           initialFetch[2].split('-')[0]
-        }` : 'recruitment.person.getPerson'}.fetch(
+        }.fetch({ id })` : `recruitment.person.getPerson.fetch(
           { personCode: id },
-        ), {
+        )`}, {
           ready: !!id,
           onSuccess: data => {
             const values = {

--- a/src/manage/templates/longForm.ts
+++ b/src/manage/templates/longForm.ts
@@ -3,17 +3,19 @@
  * @公司: thundersdata
  * @作者: 陈杰
  * @Date: 2020-05-08 16:05:30
- * @LastEditors: 黄姗姗
- * @LastEditTime: 2020-05-25 09:48:07
+ * @LastEditors: 廖军
+ * @LastEditTime: 2020-10-10 10:15:36
  */
 import { createFormComponentsByType, transformFormItemLines, generateRules, generateBreadcrumbs } from './util';
 import { CardItemProps, FormItemProps } from '../../../interfaces/common';
+import { getPageNameByPath } from '..';
 
 export interface Payload {
   cards: CardItemProps[];
   initialFetch?: string[];
   submitFetch?: string[];
   menu: string;
+  path: string;
 }
 
 export default function generateLongFormCode(payload: Payload): string {
@@ -55,6 +57,7 @@ export default function generateLongFormCode(payload: Payload): string {
       import useSpinning from '@/hooks/useSpinning';
       import FooterToolbar from '@/components/FooterToolbar';
       ${breadcrumbs.length > 1 && `import CustomBreadcrumb from '@/components/CustomBreadcrumb';`}
+      import { getVerificationRules } from '@/pages/${getPageNameByPath(payload.path)}/validators';
       console.log('emptyline');
       const colLayout = {
         lg: {
@@ -80,9 +83,9 @@ export default function generateLongFormCode(payload: Payload): string {
             setTip('加载详情中，请稍候...');
             return API.${initialFetch && initialFetch.length === 3 ? `${initialFetch[0]}.${initialFetch[1]}.${
               initialFetch[2].split('-')[0]
-            }` : 'recruitment.person.getPerson'}.fetch(
+            }.fetch({ id })` : `recruitment.person.getPerson.fetch(
               { personCode: id },
-            );
+            )`};
           }
           return Promise.resolve(false);
         };
@@ -151,7 +154,7 @@ export default function generateLongFormCode(payload: Payload): string {
                                     label="${label}"
                                     name="${name}"
                                     ${required ? `required` : ``}
-                                    ${rules !== '[]' ? `rules={${rules}}` : ''}
+                                    ${`rules={[...${rules}, ...getVerificationRules('${name}').rules]}`}
                                     ${type === 'upload' ? `
                                     valuePropName="fileList"
                                     getValueFromEvent={e => {

--- a/src/manage/templates/longFormModal.ts
+++ b/src/manage/templates/longFormModal.ts
@@ -3,18 +3,20 @@
  * @公司: thundersdata
  * @作者: 陈杰
  * @Date: 2020-05-08 16:05:30
- * @LastEditors: 黄姗姗
- * @LastEditTime: 2020-05-25 09:48:26
+ * @LastEditors: 廖军
+ * @LastEditTime: 2020-10-10 10:15:44
  */
 import { createFormComponentsByType, transformFormItemLines, generateRules } from './util';
 import { FormItemProps } from '../../../interfaces/common';
 import { Store } from 'antd/lib/form/interface';
+import { getPageNameByPath } from '..';
 
 export interface Payload {
   formConfig: Store;
   formItems: FormItemProps[];
   submitFetch?: string[];
   fromTable: boolean;
+  path: string;
 }
 
 export default function generateLongFormModalCode(payload: Payload): string {
@@ -56,6 +58,7 @@ export default function generateLongFormModalCode(payload: Payload): string {
       import { useRequest } from 'ahooks';
       import useSpinning from '@/hooks/useSpinning';
       ${fromTable && `import { ActionType } from '@ant-design/pro-table';`}
+      import { getVerificationRules } from '@/pages/${getPageNameByPath(payload.path)}/validators';
       console.log('emptyline');
       const twoColumnsLayout = {
         labelCol: { span: 8 },
@@ -147,7 +150,7 @@ export default function generateLongFormModalCode(payload: Payload): string {
                                   label="${label}"
                                   name="${name}"
                                   ${required ? `required` : ``}
-                                  ${rules !== '[]' ? `rules={${rules}}` : ''}
+                                  ${`rules={[...${rules}, ...getVerificationRules('${name}').rules]}`}
                                   ${type === 'upload' ? `
                                   valuePropName="fileList"
                                   getValueFromEvent={e => {

--- a/src/manage/templates/shortDetail.ts
+++ b/src/manage/templates/shortDetail.ts
@@ -3,8 +3,8 @@
  * @公司: thundersdata
  * @作者: 陈杰
  * @Date: 2020-05-07 14:04:41
- * @LastEditors: 黄姗姗
- * @LastEditTime: 2020-05-22 17:04:35
+ * @LastEditors: 廖军
+ * @LastEditTime: 2020-10-09 15:39:08
  */
 import { Store } from 'antd/lib/form/interface';
 import { FormItemProps } from '../../../interfaces/common';
@@ -50,9 +50,9 @@ export default function generateShortDetail(payload: Payload): string {
         console.log('emptyline');
         const { loading } = useRequest(API.${initialFetch && initialFetch.length === 3 ? `${initialFetch[0]}.${initialFetch[1]}.${
           initialFetch[2].split('-')[0]
-        }` : 'recruitment.person.getPerson'}.fetch(
+        }.fetch({ id })` : `recruitment.person.getPerson.fetch(
           { personCode: id },
-        ), {
+        )`}, {
           ready: !!id,
           onSuccess: data => {
             const values = {

--- a/src/manage/templates/shortForm.ts
+++ b/src/manage/templates/shortForm.ts
@@ -3,12 +3,13 @@
  * @公司: thundersdata
  * @作者: 陈杰
  * @Date: 2020-05-07 14:04:41
- * @LastEditors: 黄姗姗
- * @LastEditTime: 2020-05-25 09:48:39
+ * @LastEditors: 廖军
+ * @LastEditTime: 2020-10-10 10:10:28
  */
 import { Store } from 'antd/lib/form/interface';
 import { createFormComponentsByType, generateRules, generateBreadcrumbs } from './util';
 import { FormItemProps } from '../../../interfaces/common';
+import { getPageNameByPath } from '..';
 
 export interface Payload {
   formConfig: Store;
@@ -16,6 +17,7 @@ export interface Payload {
   initialFetch?: string[];
   submitFetch?: string[];
   menu: string;
+  path: string;
 }
 
 export default function generateShortFormCode(payload: Payload): string {
@@ -53,6 +55,7 @@ export default function generateShortFormCode(payload: Payload): string {
       import Title from '@/components/Title';
       import useSpinning from '@/hooks/useSpinning';
       ${breadcrumbs.length > 1 && `import CustomBreadcrumb from '@/components/CustomBreadcrumb';`}
+      import { getVerificationRules } from '@/pages/${getPageNameByPath(payload.path)}/validators';
       console.log('emptyline');
       const formItemLayout = {
         labelCol: {
@@ -85,9 +88,9 @@ export default function generateShortFormCode(payload: Payload): string {
               setTip('加载详情中，请稍候...');
               return API.${initialFetch && initialFetch.length === 3 ? `${initialFetch[0]}.${initialFetch[1]}.${
                 initialFetch[2].split('-')[0]
-              }` : 'recruitment.person.getPerson'}.fetch(
+              }.fetch({ id })` : `recruitment.person.getPerson.fetch(
                 { personCode: id },
-              );
+              )`};
             }
             return Promise.resolve(false);
         };
@@ -142,7 +145,7 @@ export default function generateShortFormCode(payload: Payload): string {
                       label="${label}"
                       name="${name}"
                       ${required ? `required` : ``}
-                      ${rules !== '[]' ? `rules={${rules}}` : ''}
+                      ${`rules={[...${rules}, ...getVerificationRules('${name}').rules]}`}
                       ${item.type === 'upload' ? `
                       valuePropName="fileList"
                       getValueFromEvent={e => {

--- a/src/manage/templates/shortFormModal.ts
+++ b/src/manage/templates/shortFormModal.ts
@@ -3,18 +3,20 @@
  * @公司: thundersdata
  * @作者: 陈杰
  * @Date: 2020-05-07 14:04:41
- * @LastEditors: 黄姗姗
- * @LastEditTime: 2020-05-22 17:05:04
+ * @LastEditors: 廖军
+ * @LastEditTime: 2020-10-10 10:15:51
  */
 import { Store } from 'antd/lib/form/interface';
 import { createFormComponentsByType, generateRules } from './util';
 import { FormItemProps } from '../../../interfaces/common';
+import { getPageNameByPath } from '..';
 
 export interface Payload {
   formConfig: Store;
   formItems: FormItemProps[];
   submitFetch?: string[];
   fromTable: boolean;
+  path: string;
 }
 
 export default function generateShortFormModalCode(payload: Payload): string {
@@ -50,6 +52,7 @@ export default function generateShortFormModalCode(payload: Payload): string {
       import { useRequest } from 'ahooks';
       import useSpinning from '@/hooks/useSpinning';
       ${fromTable && `import { ActionType } from '@ant-design/pro-table';`}
+      import { getVerificationRules } from '@/pages/${getPageNameByPath(payload.path)}/validators';
       console.log('emptyline');
       const formLayout = {
         labelCol: { span: 6 },
@@ -134,7 +137,7 @@ export default function generateShortFormModalCode(payload: Payload): string {
                       label="${label}"
                       name="${name}"
                       ${required ? `required` : ``}
-                      ${rules !== '[]' ? `rules={${rules}}` : ''}
+                      ${`rules={[...${rules}, ...getVerificationRules('${name}').rules]}`}
                       ${type === 'upload' ? `
                       valuePropName="fileList"
                       getValueFromEvent={e => {


### PR DESCRIPTION
1、修复表单获取详情写法；
2、添加字段校验文件生成（生成表单试默认生成，且与插件本身的rules独立，用于与毕晟平台校验兼容）。